### PR TITLE
* Create indirect symbol  fo record RTTI to initrtti structure which …

### DIFF
--- a/compiler/ncgrtti.pas
+++ b/compiler/ncgrtti.pas
@@ -1030,12 +1030,13 @@ implementation
            { store rtti management operators only for init table }
            if (rt=initrtti) then
            begin
-             tcb.emit_tai(Tai_const.Create_nil_codeptr,voidpointertype);
+             tcb.emit_tai(Tai_const.Create_nil_dataptr,voidpointertype);
              if (trecordsymtable(def.symtable).managementoperators=[]) then
-               tcb.emit_tai(Tai_const.Create_nil_codeptr,voidpointertype)
+               tcb.emit_tai(Tai_const.Create_nil_dataptr,voidpointertype)
              else
                tcb.emit_tai(Tai_const.Createname(
-                 internaltypeprefixName[itp_init_record_operators]+def.rtti_mangledname(rt),AT_DATA,0),voidpointertype);
+                 internaltypeprefixName[itp_init_record_operators]+def.rtti_mangledname(rt),
+                 AT_DATA_FORCEINDIRECT,0),voidpointertype);
            end else
            begin
              Include(def.defstates, ds_init_table_used);
@@ -1187,9 +1188,9 @@ implementation
           begin
             tcb.emit_ord_const(def.size, u32inttype);
             { inittable terminator for vmt vInitTable }
-            tcb.emit_tai(Tai_const.Create_nil_codeptr,voidpointertype);
+            tcb.emit_tai(Tai_const.Create_nil_dataptr,voidpointertype);
             { pointer to management operators }
-            tcb.emit_tai(Tai_const.Create_nil_codeptr,voidpointertype);
+            tcb.emit_tai(Tai_const.Create_nil_dataptr,voidpointertype);
             { enclosing record takes care of alignment }
             fields_write_rtti_data(tcb,def,rt);
           end;

--- a/rtl/inc/rtti.inc
+++ b/rtl/inc/rtti.inc
@@ -50,7 +50,7 @@ type
   record
     Size: Longint;
 {$if FPC_FULLVERSION>30100}
-    InitTable: Pointer;
+    InitTable: PPointer;
 {$endif FPC_FULLVERSION>30100}
     Count: Longint;
     { Elements: array[count] of TRecordElement }
@@ -130,7 +130,7 @@ begin
   if Assigned(result^.Terminator) then
   begin
     { point to more optimal initrtti }
-    initrtti:=PRecordInfoFull(result)^.InitTable;
+    initrtti:=PRecordInfoFull(result)^.InitTable^;
     { and point to management operators in our init table }
     result:=aligntoptr(initrtti+2+PByte(initrtti)[1]);
   end


### PR DESCRIPTION
…contains record operators VMT and "real" managed fields list.
- Use Create_nil_dataptr instead of Create_nil_codeptr in right places.
